### PR TITLE
Update to drone-scp 1.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM appleboy/drone-scp:1.5.5-linux-amd64
+FROM appleboy/drone-scp:1.5.6-linux-amd64
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
To pull in the fix for the typo related to proxy_paraphrase