### PR TITLE
chore: upgrade drone-scp to v1.6.7 version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-scp:latest
+FROM ghcr.io/appleboy/drone-scp:1.6.7
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM appleboy/drone-scp:1.6.4-linux-amd64
+FROM ghcr.io/appleboy/drone-scp:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
try the following version:

```diff
  build:
    name: Build
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    - name: copy file via ssh password
-     uses: appleboy/scp-action@master
+     uses: appleboy/scp-action@7af00892de6f8397c5c3393cfb3b32ae7f91b94b
      with:
        host: ${{ secrets.HOST }}
        username: ${{ secrets.USERNAME }}
        password: ${{ secrets.PASSWORD }}
        port: ${{ secrets.PORT }}
        source: "tests/a.txt,tests/b.txt"
        target: "test"
```