### PR TITLE
feat: add new input for tar executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See the [action.yml](./action.yml) file for more detail information.
 * strip_components - remove the specified number of leading path elements.
 * overwrite - use `--overwrite` flag with tar
 * tar_tmp_path - temporary path for tar file on the dest host
+* tar_exec - path to tar executable on the dest host. default is `tar`
 * use_insecure_cipher - include more ciphers with use_insecure_cipher (see [#15](https://github.com/appleboy/scp-action/issues/15))
 
 SSH Proxy Setting:

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
     default: false
   tar_tmp_path:
     description: 'temporary path for tar file on the dest host'
+  tar_exec:
+    description: 'temporary path for tar file on the dest host'
+    default: 'tar'
   proxy_host:
     description: 'ssh proxy remote host'
   proxy_port:


### PR DESCRIPTION
- Add new input `tar_exec` with description and default value

fix https://github.com/appleboy/drone-scp/issues/137
fix https://github.com/appleboy/scp-action/issues/83