### PR TITLE
ci: add deployment workflow for artifact delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,32 @@ jobs:
         source: "tests/a.txt,tests/b.txt"
         target: "test"
         use_insecure_cipher: true
+
+  deploy:
+    name: deploy artifact
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - run: echo hello > world.txt
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: my-artifact
+        path: world.txt
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: my-artifact
+        path: distfiles
+
+    - name: copy file to server
+      uses: ./
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        source: distfiles/*
+        target: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: scp files
 on: [push]
 jobs:
 
-  build:
-    name: Build
+  testing:
+    name: test scp action
     runs-on: ubuntu-latest
     steps:
     - name: checkout

--- a/README.md
+++ b/README.md
@@ -203,6 +203,39 @@ Example configuration for exclude custom files:
     target: "test"
 ```
 
+Upload artifact files to remote server:
+
+```yaml
+  deploy:
+    name: deploy artifact
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - run: echo hello > world.txt
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: my-artifact
+        path: world.txt
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: my-artifact
+        path: distfiles
+
+    - name: copy file to server
+      uses: appleboy/scp-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        source: distfiles/*
+        target: test
+```
+
 Remove the specified number of leading path elements:
 
 ```yaml


### PR DESCRIPTION
- Add a deployment job to the CI workflow
- Upload `world.txt` as an artifact
- Download the artifact to the `distfiles` directory
- Add a step to copy files to a server using SSH

fix https://github.com/appleboy/scp-action/issues/35