### PR TITLE
chore: i/o timeout issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-scp:1.6.7
+FROM ghcr.io/appleboy/drone-scp:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
try the following version:

```diff
  build:
    name: Build
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    - name: copy file via ssh password
-     uses: appleboy/scp-action@master
+     uses: appleboy/scp-action@209e8c05e0492f6ed6fe8a22dfcaefb083c4cf35
      with:
        host: ${{ secrets.HOST }}
        username: ${{ secrets.USERNAME }}
        password: ${{ secrets.PASSWORD }}
        port: ${{ secrets.PORT }}
        source: "tests/a.txt,tests/b.txt"
        target: "test"
```

ref issue: https://github.com/appleboy/scp-action/issues/106 and https://github.com/appleboy/drone-scp/issues/170