### PR TITLE
chore: update Docker image for drone-scp to version 1.6.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         key: ${{ secrets.KEY }}
         port: ${{ secrets.PORT }}
         source: tests/a.txt,tests/b.txt
-        target: test foobar
+        target: foobar foobar   1234
 
   multipleHost:
     name: test Multiple Host

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-scp:1.6.9
+FROM ghcr.io/appleboy/drone-scp:1.6.10
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
- Update the `drone-scp` Docker image from version `1.6.9` to `1.6.10`

fix https://github.com/appleboy/scp-action/issues/112