### PR TITLE
chore: update drone-scp image to v1.6.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-scp:1.6.12
+FROM ghcr.io/appleboy/drone-scp:1.6.13
 
 COPY entrypoint.sh /bin/entrypoint.sh
 


### PR DESCRIPTION
- Update the drone-scp image from version `1.6.12` to `1.6.13` in the Dockerfile