### PR TITLE
feat: migrate to composite action with dynamic drone-scp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM ghcr.io/appleboy/drone-scp:1.6.14
-
-COPY entrypoint.sh /bin/entrypoint.sh
-
-ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -71,9 +71,71 @@ inputs:
     description: "fingerprint SHA256 of the host public key, default is to skip verification"
   proxy_use_insecure_cipher:
     description: "include more ciphers with use_insecure_cipher"
+  curl_insecure:
+    description: "When true, uses the --insecure option with curl for insecure downloads."
+    default: "false"
+  capture_stdout:
+    description: "When true, captures and returns standard output from the commands as action output."
+    default: "false"
+  version:
+    description: |
+      The version of drone-scp to use.
+
+outputs:
+  stdout:
+    description: "Standard output of the executed commands when capture_stdout is enabled."
+    value: ${{ steps.entrypoint.outputs.stdout }}
+
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: "composite"
+  steps:
+    - name: Set GitHub Path
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+    - id: entrypoint
+      name: Run entrypoint.sh
+      run: entrypoint.sh
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+        INPUT_HOST: ${{ inputs.host }}
+        INPUT_PORT: ${{ inputs.port }}
+        INPUT_PROTOCOL: ${{ inputs.protocol }}
+        INPUT_USERNAME: ${{ inputs.username }}
+        INPUT_PASSWORD: ${{ inputs.password }}
+        INPUT_PASSPHRASE: ${{ inputs.passphrase }}
+        INPUT_KEY: ${{ inputs.key }}
+        INPUT_KEY_PATH: ${{ inputs.key_path }}
+        INPUT_FINGERPRINT: ${{ inputs.fingerprint }}
+        INPUT_PROXY_HOST: ${{ inputs.proxy_host }}
+        INPUT_PROXY_PORT: ${{ inputs.proxy_port }}
+        INPUT_PROXY_USERNAME: ${{ inputs.proxy_username }}
+        INPUT_PROXY_PASSWORD: ${{ inputs.proxy_password }}
+        INPUT_PROXY_PASSPHRASE: ${{ inputs.proxy_passphrase }}
+        INPUT_PROXY_KEY: ${{ inputs.proxy_key }}
+        INPUT_PROXY_KEY_PATH: ${{ inputs.proxy_key_path }}
+        INPUT_PROXY_FINGERPRINT: ${{ inputs.proxy_fingerprint }}
+        INPUT_USE_INSECURE_CIPHER: ${{ inputs.use_insecure_cipher }}
+        INPUT_CIPHER: ${{ inputs.cipher }}
+        INPUT_PROXY_USE_INSECURE_CIPHER: ${{ inputs.proxy_use_insecure_cipher }}
+        INPUT_PROXY_CIPHER: ${{ inputs.proxy_cipher }}
+        INPUT_DEBUG: ${{ inputs.debug }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_COMMAND_TIMEOUT: ${{ inputs.command_timeout }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_SOURCE: ${{ inputs.source }}
+        INPUT_RM: ${{ inputs.rm }}
+        INPUT_STRIP_COMPONENTS: ${{ inputs.strip_components }}
+        INPUT_OVERWRITE: ${{ inputs.overwrite }}
+        INPUT_TAR_DEREFERENCE: ${{ inputs.tar_dereference }}
+        INPUT_TAR_TMP_PATH: ${{ inputs.tar_tmp_path }}
+        INPUT_TAR_EXEC: ${{ inputs.tar_exec }}
+        INPUT_PROXY_TIMEOUT: ${{ inputs.proxy_timeout }}
+        INPUT_CAPTURE_STDOUT: ${{ inputs.capture_stdout }}
+        INPUT_CURL_INSECURE: ${{ inputs.curl_insecure }}
+        DRONE_SCP_VERSION: ${{ inputs.version }}
 
 branding:
   icon: "copy"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,56 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
-[ -n "$INPUT_STRIP_COMPONENTS" ] && export INPUT_STRIP_COMPONENTS=$((INPUT_STRIP_COMPONENTS + 0))
+export GITHUB="true"
 
-sh -c "/bin/drone-scp $*"
+GITHUB_ACTION_PATH="${GITHUB_ACTION_PATH%/}"
+DRONE_SCP_RELEASE_URL="${DRONE_SCP_RELEASE_URL:-https://github.com/appleboy/drone-scp/releases/download}"
+DRONE_SCP_VERSION="${DRONE_SCP_VERSION:-1.7.0}"
+
+function log_error() {
+  echo "$1" >&2
+  exit "$2"
+}
+
+function detect_client_info() {
+  CLIENT_PLATFORM="${SCP_CLIENT_OS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
+  CLIENT_ARCH="${SCP_CLIENT_ARCH:-$(uname -m)}"
+
+  case "${CLIENT_PLATFORM}" in
+  darwin | linux | windows) ;;
+  *) log_error "Unknown or unsupported platform: ${CLIENT_PLATFORM}. Supported platforms are Linux, Darwin, and Windows." 2 ;;
+  esac
+
+  case "${CLIENT_ARCH}" in
+  x86_64* | i?86_64* | amd64*) CLIENT_ARCH="amd64" ;;
+  aarch64* | arm64*) CLIENT_ARCH="arm64" ;;
+  *) log_error "Unknown or unsupported architecture: ${CLIENT_ARCH}. Supported architectures are x86_64, i686, and arm64." 3 ;;
+  esac
+}
+
+detect_client_info
+DOWNLOAD_URL_PREFIX="${DRONE_SCP_RELEASE_URL}/v${DRONE_SCP_VERSION}"
+CLIENT_BINARY="drone-scp-${DRONE_SCP_VERSION}-${CLIENT_PLATFORM}-${CLIENT_ARCH}"
+TARGET="${GITHUB_ACTION_PATH}/${CLIENT_BINARY}"
+echo "Downloading ${CLIENT_BINARY} from ${DOWNLOAD_URL_PREFIX}"
+INSECURE_OPTION=""
+if [[ "${INPUT_CURL_INSECURE}" == 'true' ]]; then
+  INSECURE_OPTION="--insecure"
+fi
+
+curl -fsSL --retry 5 --keepalive-time 2 ${INSECURE_OPTION} "${DOWNLOAD_URL_PREFIX}/${CLIENT_BINARY}" -o "${TARGET}"
+chmod +x "${TARGET}"
+
+echo "======= CLI Version Information ======="
+"${TARGET}" --version
+echo "======================================="
+if [[ "${INPUT_CAPTURE_STDOUT}" == 'true' ]]; then
+  {
+    echo 'stdout<<EOF'
+    "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"
+    echo 'EOF'
+  } >>"${GITHUB_OUTPUT}"
+else
+  "${TARGET}" "$@"
+fi


### PR DESCRIPTION
- Remove Dockerfile and switch the action implementation from Docker to composite actions
- Add support for specifying the drone-scp version and automatically download the appropriate binary at runtime
- Add new inputs: curl_insecure, capture_stdout, and version for improved flexibility and output handling
- Add output for capturing standard output from executed commands when enabled
- entrypoint.sh refactored from sh to bash and made more robust with error handling, dynamic platform/architecture detection, and secure downloading of the binary
- Action now works cross-platform rather than being tied to a specific Docker image