### PR TITLE
feat: avoid redundant binary downloads and notify when skipping

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,8 +39,12 @@ if [[ "${INPUT_CURL_INSECURE}" == 'true' ]]; then
   INSECURE_OPTION="--insecure"
 fi
 
-curl -fsSL --retry 5 --keepalive-time 2 ${INSECURE_OPTION} "${DOWNLOAD_URL_PREFIX}/${CLIENT_BINARY}" -o "${TARGET}"
-chmod +x "${TARGET}"
+if [[ ! -f "${TARGET}" ]]; then
+  curl -fsSL --retry 5 --keepalive-time 2 ${INSECURE_OPTION} "${DOWNLOAD_URL_PREFIX}/${CLIENT_BINARY}" -o "${TARGET}"
+  chmod +x "${TARGET}"
+else
+  echo "Binary ${CLIENT_BINARY} already exists, skipping download."
+fi
 
 echo "======= CLI Version Information ======="
 "${TARGET}" --version


### PR DESCRIPTION
- Skip downloading the binary if it already exists, and print a message instead

fixed #202 