### PR TITLE
docs: explain how strip_components works for english readme for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
 | source           | Local files/directories to transfer (comma-separated)   | -       | Use explicit paths     |
 | target           | Target directory on remote server (must be a directory) | -       | Avoid root directories |
 | rm               | Remove target directory before upload                   | -       | Use with caution       |
-| strip_components | Remove leading path elements when extracting            | -       |                        |
+| strip_components | Remove leading path elements when extracting            | 0       | The amount of path components to strip from the source path |
 | overwrite        | Overwrite existing files with tar                       | -       |                        |
 | tar_dereference  | Follow symlinks with tar                                | -       |                        |
 | tar_tmp_path     | Temp path for tar file on destination                   | -       |                        |


### PR DESCRIPTION
I think the README could be more explicit about what value type is expected as well as a security note that it is an amount of components to strip.

I'm happy to edit this as needed, but I think it would prevent some users from the inevitable bad commit in which they try to pass "true" instead of a number value.